### PR TITLE
changing test-train split to 75-25 for better accuracy

### DIFF
--- a/mood_tracker/mood_tracker/wsgi.py
+++ b/mood_tracker/mood_tracker/wsgi.py
@@ -47,8 +47,8 @@ if not os.path.isfile('trained_model_obj'):
     y_kmeans = kmeans.predict(songs_features)
     y = y_kmeans
 
-    # Doing test-train split of 95% training data and 5% testing data
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.05)
+    # Doing test-train split of 75% training data and 25% testing data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25)
     songs['label'] = y_kmeans
 
     # Fitting MLP model


### PR DESCRIPTION
Notice that increasing the test-train split to values >80% reduces the accuracy on further predictions as the model then memorizes the training data, hence 75-80% is a better number, with 75% giving us the best results.